### PR TITLE
Add /team page empty state

### DIFF
--- a/apps/web/src/app/team/page.tsx
+++ b/apps/web/src/app/team/page.tsx
@@ -2,13 +2,15 @@
 
 import LoadingState from '@components/loading-state';
 import PageHeader from '@components/page-header';
-import PokemonCard from '@components/slots/cards';
+import { EmptyPokemonCard, FilledPokemonCard } from '@components/slots/cards';
 import SlotConfigModal from '@components/slots/config-modal';
+import { queryClient } from '@rq-client/index';
 import withTeamStore, { WithTeamStoreProps } from '@state/hoc/with-store';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { Dialog, DialogTrigger } from 'ui';
-
-const queryClient = new QueryClient();
+import { BaseSlot } from '@state/team/helpers';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { MAX_TEAM_MEMBERS } from 'contract';
+import Link from 'next/link';
+import { Button, Dialog, DialogTrigger, Typography } from 'ui';
 
 interface BuilderProps extends WithTeamStoreProps {}
 
@@ -16,6 +18,7 @@ function Builder({ teamStore }: BuilderProps): JSX.Element {
   const { slots, setSelectedSlotIndex } = teamStore;
 
   const areThereSlots = slots.length > 0;
+  const emptySlots = MAX_TEAM_MEMBERS - slots.length;
 
   function handleSetSelectedSlotIndex(index: number): void {
     setSelectedSlotIndex(index);
@@ -28,25 +31,48 @@ function Builder({ teamStore }: BuilderProps): JSX.Element {
           description='Your current team. Click on one card to edit. When you are done, copy it from the right sidebar.'
           title='Team'
         />
-        <div className='flex flex-wrap justify-center gap-6'>
-          {areThereSlots
-            ? slots.map((slot) => {
-                return (
-                  <DialogTrigger
-                    key={slot.id}
-                    onClick={() => {
-                      handleSetSelectedSlotIndex(slot.order);
-                    }}
-                  >
-                    <PokemonCard slot={slot} />
-                  </DialogTrigger>
-                );
-              })
-            : null}
-        </div>
+        {areThereSlots ? (
+          <div className='flex flex-wrap justify-center gap-6'>
+            {slots.map((slot) => {
+              return (
+                <DialogTrigger
+                  key={slot.id}
+                  onClick={() => {
+                    // FIX: este handler esta generando un bug al abrir el config modal
+                    // de un pokemon diferente al del index que esta seleccionado
+                    handleSetSelectedSlotIndex(slot.order);
+                  }}
+                >
+                  <FilledPokemonCard slot={slot} />
+                </DialogTrigger>
+              );
+            })}
+            {Array(emptySlots)
+              .fill(new BaseSlot())
+              .map((_, i) => {
+                return <EmptyPokemonCard key={i} />;
+              })}
+          </div>
+        ) : (
+          <EmptyState />
+        )}
+
         {areThereSlots ? <SlotConfigModal /> : null}
       </Dialog>
     </QueryClientProvider>
+  );
+}
+
+function EmptyState(): JSX.Element {
+  return (
+    <div className='flex flex-1 w-full justify-center items-center'>
+      <Typography.Muted>No pokemon selected yet.</Typography.Muted>
+      <Link href={`/pokemon`}>
+        <Button className='px-2' variant='link'>
+          Add some.
+        </Button>
+      </Link>
+    </div>
   );
 }
 

--- a/apps/web/src/components/slots/cards/index.tsx
+++ b/apps/web/src/components/slots/cards/index.tsx
@@ -1,19 +1,20 @@
 import { GendersText } from '@components/pokemon-table/components/genders-text';
 import { calculateHiddenPowerType } from '@utils/pokemon';
-import { Card, CardContent, CardHeader, PokemonSprite, TypeBadge, Typography } from 'ui';
+import { Button, Card, CardContent, CardHeader, PokemonSprite, TypeBadge, Typography } from 'ui';
 import PokemonCardMoves from './components/card-moves';
 import PokemonCardStats from './components/card-stats';
 import CardInfoField from './components/info-field';
 import { getCardTitleName } from './utils/get-card-title';
 import { FilledSlot } from 'contract';
+import Link from 'next/link';
 
 interface PokemonCardProps {
   slot: FilledSlot;
 }
 
-export default function PokemonCard({ slot }: PokemonCardProps): JSX.Element {
+export function FilledPokemonCard({ slot }: PokemonCardProps): JSX.Element {
   return (
-    <Card className='w-[500px] hover:bg-slate-700 hover:cursor-pointer transition duration-150 ease-in-out'>
+    <Card className='w-[500px] min-h-[332px] hover:bg-primary-foreground hover:cursor-pointer transition duration-150 ease-in-out'>
       <CardHeader>
         <div className='flex items-center justify-between gap-5'>
           <Typography.H3 className='truncate'>{getCardTitleName(slot)}</Typography.H3>
@@ -52,6 +53,19 @@ export default function PokemonCard({ slot }: PokemonCardProps): JSX.Element {
           <PokemonCardStats slot={slot} />
         </div>
       </CardContent>
+    </Card>
+  );
+}
+
+export function EmptyPokemonCard(): JSX.Element {
+  return (
+    <Card className='flex min-h-[332px] justify-center items-center w-[500px] p-6'>
+      <Typography.Muted className='text-center'>Empty.</Typography.Muted>
+      <Link href={`/pokemon`}>
+        <Button className='px-2' variant='link'>
+          Add pokemon.
+        </Button>
+      </Link>
     </Card>
   );
 }


### PR DESCRIPTION
## Overview

Se agrego el empty state de /team en el caso de que no se tenga ningun pokemon seleccinado y tambien varias cards que demuestran un slot vacio en el caso de que se tengan pokemon seleccionados pero estos sean menos de 6.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe)
