### PR TITLE
Center main layout description text

### DIFF
--- a/apps/web/src/components/page-header/index.tsx
+++ b/apps/web/src/components/page-header/index.tsx
@@ -11,7 +11,7 @@ export default function PageHeader({ title, description }: PageHeaderProps): JSX
   return (
     <div className='flex flex-col items-center' style={{ height: PAGE_HEADER_HEIGHT }}>
       <Typography.H1>{title}</Typography.H1>
-      {description ? <Typography.P>{description}</Typography.P> : null}
+      {description ? <Typography.P className='text-center'>{description}</Typography.P> : null}
     </div>
   );
 }


### PR DESCRIPTION
## Overview

En el main layout de las paginas la descripcion de las mismas no tenia el texto centrado. Esto se hacia notorio en tamaños pequeños de pantalla.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe)
