### PR TITLE
Fix error when removing last slot if it was selected

### DIFF
--- a/apps/web/src/state/team/index.ts
+++ b/apps/web/src/state/team/index.ts
@@ -45,6 +45,7 @@ const store = immer<TeamStore>((set) => ({
         newSlots[i].order = i;
       }
 
+      state.selectedSlotIndex = 0;
       state.slots = newSlots;
     });
   },


### PR DESCRIPTION
## Overview

Cuando se eliminaba el ultimo slot, y si este estaba seleccionado, el valor de `selectedSlotIndex` seguia siendo el mismo. Esto generaba que en el array de `slots` se este seleccionando un elemento que no existia. Se soluciono esto haciendo que cuando se elimine un slot, el valor de `selectedSlotIndex` se reinicie a 0.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe)
