### PR TITLE
Show placeholder while loading and on error

### DIFF
--- a/packages/ui/src/components/ui/pokemon-sprite/index.tsx
+++ b/packages/ui/src/components/ui/pokemon-sprite/index.tsx
@@ -1,16 +1,28 @@
-import type { PokemonWithAbilities } from 'contract';
+import type { Pokemon } from 'contract';
 import Image from 'next/image';
+import { useEffect, useState } from 'react';
+import substitute from '../../sprites/pokemon/substitute.png';
 
 interface PokemonSpriteProps {
-  pokemon: Pick<PokemonWithAbilities, 'name' | 'sprite'>;
+  pokemon: Pick<Pokemon, 'name' | 'sprite'>;
   size?: number;
 }
 
 export function PokemonSprite({ pokemon, size = 64 }: PokemonSpriteProps): JSX.Element {
+  const [src, setSrc] = useState(substitute);
   const containerClassName = `w-[${size}px] h-[${size}px]`;
+
+  useEffect(() => {
+    setSrc(pokemon.sprite);
+  }, [pokemon]);
+
+  function replaceWithSubtitute(): void {
+    setSrc(substitute);
+  }
+
   return (
     <div className={containerClassName}>
-      <Image alt={pokemon.name} height={size} priority quality={10} src={pokemon.sprite} width={size} />
+      <Image alt={pokemon.name} height={size} priority quality={10} src={src} width={size} onError={replaceWithSubtitute} />
     </div>
   );
 }


### PR DESCRIPTION
## Overview

El componente PokemonSprite ahora muestra la imagen del sustituto mientras carga y tambien si se genera un error al cargar la imagen.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe)
