### PR TITLE
Add visual feedback for delete on right sidebar

### DIFF
--- a/apps/web/src/components/remove-pokemon-button/index.tsx
+++ b/apps/web/src/components/remove-pokemon-button/index.tsx
@@ -1,0 +1,56 @@
+import { getCardTitleName } from '@components/slots/cards/utils/get-card-title';
+import { LocalSlot } from 'contract';
+import {
+  Button,
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  toast,
+} from 'ui';
+
+interface RemoveButtonProps {
+  onRemoveClick: (slot: LocalSlot, order: number) => void;
+  slot: LocalSlot;
+  order: number;
+  children: React.ReactNode;
+}
+
+export function RemovePokemonButton(props: RemoveButtonProps): JSX.Element {
+  const descriptionTxt = `You are about to remove ${getCardTitleName(props.slot, props.order, true)}.`;
+
+  function handleClear(): void {
+    props.onRemoveClick(props.slot, props.order);
+    toast({
+      title: `${getCardTitleName(props.slot, props.order, true)} was removed.`,
+      variant: 'destructive',
+    });
+  }
+
+  return (
+    <Dialog>
+      <DialogTrigger>{props.children}</DialogTrigger>
+
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Are you sure?</DialogTitle>
+        </DialogHeader>
+        <DialogDescription>{descriptionTxt}</DialogDescription>
+        <DialogFooter>
+          <DialogClose>
+            <Button variant='outline'>Cancel</Button>
+          </DialogClose>
+          <DialogClose>
+            <Button onClick={handleClear} variant='destructive'>
+              Remove
+            </Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/remove-pokemon-button/index.tsx
+++ b/apps/web/src/components/remove-pokemon-button/index.tsx
@@ -1,4 +1,4 @@
-import { getCardTitleName } from '@components/slots/cards/utils/get-card-title';
+import { getCardTitle } from '@utils/get-card-title';
 import { LocalSlot } from 'contract';
 import {
   Button,
@@ -21,12 +21,12 @@ interface RemoveButtonProps {
 }
 
 export function RemovePokemonButton(props: RemoveButtonProps): JSX.Element {
-  const descriptionTxt = `You are about to remove ${getCardTitleName(props.slot, props.order, true)}.`;
+  const descriptionTxt = `You are about to remove ${getCardTitle(props.slot, props.order, true)}.`;
 
   function handleClear(): void {
     props.onRemoveClick(props.slot, props.order);
     toast({
-      title: `${getCardTitleName(props.slot, props.order, true)} was removed.`,
+      title: `${getCardTitle(props.slot, props.order, true)} was removed.`,
       variant: 'destructive',
     });
   }

--- a/apps/web/src/components/sidebars/right-sidebar/content.tsx
+++ b/apps/web/src/components/sidebars/right-sidebar/content.tsx
@@ -4,6 +4,7 @@ import { PokemonAvatar, Separator } from 'ui';
 import { formatPokemonName, getPokemonIconUrl } from 'utils';
 import ClearButton from '../../clear-button';
 import CopyButton from '../../copy-button';
+import { RemovePokemonButton } from '@components/remove-pokemon-button';
 
 interface RightSidebarContentProps extends WithTeamStoreProps {}
 
@@ -19,20 +20,21 @@ function RightSidebarContent({ teamStore }: RightSidebarContentProps): JSX.Eleme
 
   return (
     <>
-      {slots.map((slot) => {
+      {slots.map((slot, order) => {
         const iconUrl = getPokemonIconUrl(slot.nationalPokedexNumber);
         const key = slot.meta.id;
         const name = formatPokemonName(slot.species);
         return (
-          <PokemonAvatar
-            iconUrl={iconUrl}
-            key={key}
-            name={name}
-            onClick={() => {
+          <RemovePokemonButton
+            onRemoveClick={() => {
               handleRemoveSlot(slot);
             }}
-            withBackground
-          />
+            slot={slot}
+            order={order}
+            key={key}
+          >
+            <PokemonAvatar iconUrl={iconUrl} name={name} onClick={() => {}} withBackground />
+          </RemovePokemonButton>
         );
       })}
       {emptySlots.map((_, i) => {

--- a/apps/web/src/components/slots/cards/index.tsx
+++ b/apps/web/src/components/slots/cards/index.tsx
@@ -10,7 +10,7 @@ import { calculateHiddenPowerType, getPokemonSpriteUrl } from 'utils';
 import PokemonCardMoves from './components/card-moves';
 import PokemonCardStats from './components/card-stats';
 import CardInfoField from './components/info-field';
-import { getCardTitleName } from './utils/get-card-title';
+import { getCardTitle } from '@utils/get-card-title';
 
 interface PokemonCardProps {
   slot: LocalSlot;
@@ -33,7 +33,7 @@ export function FilledPokemonCard(props: PokemonCardProps): JSX.Element {
     <Card className='w-[500px]'>
       <CardHeader>
         <div className='flex items-center justify-between gap-5'>
-          <Typography.H3 className='truncate'>{getCardTitleName(props.slot, props.order)}</Typography.H3>
+          <Typography.H3 className='truncate'>{getCardTitle(props.slot, props.order)}</Typography.H3>
           <div className='flex gap-2'>
             {pokemon && <TypeBadge type={pokemon.typeOneName} />}
             {pokemon && pokemon.typeTwoName !== 'empty' && <TypeBadge type={pokemon.typeTwoName} />}

--- a/apps/web/src/components/slots/cards/index.tsx
+++ b/apps/web/src/components/slots/cards/index.tsx
@@ -1,28 +1,11 @@
 import LoadingState from '@components/loading-state';
 import { GendersText } from '@components/pokemon-table/components/genders-text';
+import { RemovePokemonButton } from '@components/remove-pokemon-button';
 import { client } from '@rq-client/index';
 import { LocalSlot } from 'contract';
 import Link from 'next/link';
 import { MouseEventHandler } from 'react';
-import {
-  Button,
-  Card,
-  CardContent,
-  CardFooter,
-  CardHeader,
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-  PokemonSprite,
-  TypeBadge,
-  Typography,
-  toast,
-} from 'ui';
+import { Button, Card, CardContent, CardFooter, CardHeader, DialogTrigger, PokemonSprite, TypeBadge, Typography } from 'ui';
 import { calculateHiddenPowerType, getPokemonSpriteUrl } from 'utils';
 import PokemonCardMoves from './components/card-moves';
 import PokemonCardStats from './components/card-stats';
@@ -92,52 +75,13 @@ export function FilledPokemonCard(props: PokemonCardProps): JSX.Element {
             <Button variant='outline'>Edit</Button>
           </DialogTrigger>
         )}
-        {props.onRemoveClick && <RemovePokemonButton order={props.order} slot={props.slot} onRemoveClick={props.onRemoveClick} />}
+        {props.onRemoveClick && (
+          <RemovePokemonButton order={props.order} slot={props.slot} onRemoveClick={props.onRemoveClick}>
+            <Button variant='destructive'>Remove</Button>
+          </RemovePokemonButton>
+        )}
       </CardFooter>
     </Card>
-  );
-}
-
-interface RemoveButtonProps {
-  onRemoveClick: (slot: LocalSlot, order: number) => void;
-  slot: LocalSlot;
-  order: number;
-}
-
-function RemovePokemonButton(props: RemoveButtonProps): JSX.Element {
-  const descriptionTxt = `You are about to remove ${getCardTitleName(props.slot, props.order, true)}.`;
-
-  function handleClear(): void {
-    props.onRemoveClick(props.slot, props.order);
-    toast({
-      title: `${getCardTitleName(props.slot, props.order, true)} was removed.`,
-      variant: 'destructive',
-    });
-  }
-
-  return (
-    <Dialog>
-      <DialogTrigger>
-        <Button variant='destructive'>Remove</Button>
-      </DialogTrigger>
-
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Are you sure?</DialogTitle>
-        </DialogHeader>
-        <DialogDescription>{descriptionTxt}</DialogDescription>
-        <DialogFooter>
-          <DialogClose>
-            <Button variant='outline'>Cancel</Button>
-          </DialogClose>
-          <DialogClose>
-            <Button onClick={handleClear} variant='destructive'>
-              Remove
-            </Button>
-          </DialogClose>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
   );
 }
 

--- a/apps/web/src/components/slots/config-modal/index.tsx
+++ b/apps/web/src/components/slots/config-modal/index.tsx
@@ -16,9 +16,9 @@ import {
   Typography,
 } from 'ui';
 import { getPokemonSpriteUrl } from 'utils';
-import { getCardTitleName } from '../cards/utils/get-card-title';
 import { BASIC_TAB_NAME, BasicTab } from './tabs/basic-tab';
 import { MOVES_TAB_NAME, MovesTab } from './tabs/moves-tab';
+import { getCardTitle } from '@utils/get-card-title';
 
 interface SlotConfigModalProps extends WithTeamStoreProps {}
 
@@ -56,7 +56,7 @@ function ModalContent(props: ModalContentProps): JSX.Element {
         <PokemonSprite url={getPokemonSpriteUrl(props.slot.nationalPokedexNumber)} />
         <DialogHeader className='overflow-auto flex-1'>
           <div className='flex items-center justify-between gap-5'>
-            <Typography.H3 className='truncate'>{getCardTitleName({ ...props.slot }, 0)}</Typography.H3>
+            <Typography.H3 className='truncate'>{getCardTitle({ ...props.slot }, 0)}</Typography.H3>
             <div className='flex gap-2 mr-5'>
               <TypeBadge type={pokemon.typeOneName} />
               {pokemon.typeTwoName !== 'empty' && <TypeBadge type={pokemon.typeTwoName} />}

--- a/apps/web/src/utils/get-card-title.ts
+++ b/apps/web/src/utils/get-card-title.ts
@@ -4,11 +4,7 @@ import { formatPokemonName } from 'utils';
 /**
  * @param order - zero based
  */
-export function getCardTitleName(
-  { species, nickname }: Pick<LocalSlot, 'species' | 'nickname'>,
-  order: number,
-  hideNumber = false,
-): string {
+export function getCardTitle({ species, nickname }: Pick<LocalSlot, 'species' | 'nickname'>, order: number, hideNumber = false): string {
   const num = order + 1;
   let out = ``;
 

--- a/packages/ui/src/components/ui/pokemon-avatar/index.tsx
+++ b/packages/ui/src/components/ui/pokemon-avatar/index.tsx
@@ -1,26 +1,32 @@
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { cn } from '@/lib/utils';
+import { TrashIcon } from '@radix-ui/react-icons';
 import { SubstitutePlaceholder } from '../substitute-placeholder';
 
 interface PokemonAvatarProps {
   iconUrl: string | null;
-  onClick?: React.MouseEventHandler<HTMLSpanElement> | undefined;
+  onClick?: VoidFunction;
   name?: string;
   withBackground?: boolean;
 }
 
-export function PokemonAvatar({ iconUrl, name = '', withBackground = false, ...props }: PokemonAvatarProps) {
+export function PokemonAvatar({ iconUrl, name = '', withBackground = false, onClick, ...props }: PokemonAvatarProps) {
   const src = iconUrl ? iconUrl : '';
 
   return (
     <Avatar
-      className={cn(
-        'rounded-full h-12 w-12',
-        withBackground ? 'bg-primary-foreground' : 'bg-transparent',
-        Boolean(props.onClick) && 'hover:cursor-pointer',
-      )}
+      className={cn('rounded-full h-12 w-12 overflow-visible group', withBackground ? 'bg-primary-foreground' : 'bg-transparent')}
       {...props}
     >
+      {onClick && (
+        <TrashIcon
+          onClick={onClick}
+          className={cn(
+            'bg-primary-foreground rounded-full absolute text-white h-12 w-12 p-3 opacity-0 group-hover:opacity-70  transition-all ease-in-out duration-300',
+            'hover:cursor-pointer',
+          )}
+        />
+      )}
       <AvatarImage src={src} alt={name} title={name} className={cn('-mt-[9px] h-10 w-10')} />
       <AvatarFallback className={cn(withBackground ? 'bg-primary-foreground' : 'bg-transparent')}>
         <SubstitutePlaceholder />

--- a/packages/ui/src/components/ui/pokemon-avatar/index.tsx
+++ b/packages/ui/src/components/ui/pokemon-avatar/index.tsx
@@ -10,7 +10,7 @@ interface PokemonAvatarProps {
   withBackground?: boolean;
 }
 
-export function PokemonAvatar({ iconUrl, name = '', withBackground = false, onClick, ...props }: PokemonAvatarProps) {
+export function PokemonAvatar({ iconUrl, name = '', withBackground = false, ...props }: PokemonAvatarProps) {
   const src = iconUrl ? iconUrl : '';
 
   return (
@@ -18,9 +18,8 @@ export function PokemonAvatar({ iconUrl, name = '', withBackground = false, onCl
       className={cn('rounded-full h-12 w-12 overflow-visible group', withBackground ? 'bg-primary-foreground' : 'bg-transparent')}
       {...props}
     >
-      {onClick && (
+      {props.onClick && withBackground && (
         <TrashIcon
-          onClick={onClick}
           className={cn(
             'bg-primary-foreground rounded-full absolute text-white h-12 w-12 p-3 opacity-0 group-hover:opacity-70  transition-all ease-in-out duration-300',
             'hover:cursor-pointer',


### PR DESCRIPTION
## Overview

Se agrego feedback en los avatars de la barra lateral derecha para que el usuario sepa que esta por eliminar un pokemon del equipo. Ademas se agrego el modal de confirmacion en ese proceso.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe)
