### PR TITLE
Add log on stats colors range

### DIFF
--- a/packages/utils/src/pokemon/stats/index.test.ts
+++ b/packages/utils/src/pokemon/stats/index.test.ts
@@ -18,7 +18,7 @@ import {
 import { describe, expect, test } from 'vitest';
 import {
   CalculateStatProps,
-  StatColors,
+  StatsColors,
   calculateStat,
   getMinMaxStat,
   getShortStatName,
@@ -151,16 +151,23 @@ describe('getMinMaxStat', () => {
 });
 
 describe('getStatValueColor', () => {
-  test('should return the correct color for each value range', () => {
-    expect(getStatValueColor(0)).toBe(StatColors.VERY_LOW);
-    expect(getStatValueColor(9)).toBe(StatColors.VERY_LOW);
-    expect(getStatValueColor(10)).toBe(StatColors.LOW);
-    expect(getStatValueColor(29)).toBe(StatColors.LOW);
-    expect(getStatValueColor(30)).toBe(StatColors.MID);
-    expect(getStatValueColor(49)).toBe(StatColors.MID);
-    expect(getStatValueColor(50)).toBe(StatColors.HIGH);
-    expect(getStatValueColor(89)).toBe(StatColors.HIGH);
-    expect(getStatValueColor(90)).toBe(StatColors.VERY_HIGH);
-    expect(getStatValueColor(100)).toBe(StatColors.VERY_HIGH);
+  const colors: StatsColors[] = [StatsColors.VERY_LOW, StatsColors.LOW, StatsColors.MID, StatsColors.HIGH, StatsColors.VERY_HIGH];
+  test('should return a color for values between 0 and 100', () => {
+    expect(colors).toContain(getStatValueColor(0));
+    expect(colors).toContain(getStatValueColor(20));
+    expect(colors).toContain(getStatValueColor(40));
+    expect(colors).toContain(getStatValueColor(60));
+    expect(colors).toContain(getStatValueColor(80));
+    expect(colors).toContain(getStatValueColor(100));
+  });
+  test('should return "very high" color for values above 100', () => {
+    expect(colors).toContain(getStatValueColor(Infinity));
+    expect(colors).toContain(getStatValueColor(101));
+    expect(colors).toContain(getStatValueColor(150));
+  });
+  test('should return "very low" color for values below 0', () => {
+    expect(colors).toContain(getStatValueColor(-Infinity));
+    expect(colors).toContain(getStatValueColor(-100));
+    expect(colors).toContain(getStatValueColor(-1));
   });
 });

--- a/packages/utils/src/pokemon/stats/index.ts
+++ b/packages/utils/src/pokemon/stats/index.ts
@@ -130,7 +130,7 @@ export function getMinMaxStat(stat: StatID): { min: number; max: number } {
 
 // TODO: these colors should not be here
 // INFO: in sync with packages/tailwind-config/tokens/colors.ts
-export const enum StatColors {
+export const enum StatsColors {
   VERY_LOW = 'rgb(178,34,34)',
   LOW = 'rgb(255,140,0)',
   MID = 'rgb(255,255,0)',
@@ -140,19 +140,21 @@ export const enum StatColors {
 
 /**
  * Returns the color for a given percentage in RGB format.
+ * @param percentage - the percentage value to get the color for.
  * @see tailwind.config.ts
  */
-export function getStatValueColor(value: number): StatColors {
+export function getStatValueColor(percentage: number): StatsColors {
+  const logvalue = Math.log10(percentage / 10) * 100;
   switch (true) {
-    case value >= 90:
-      return StatColors.VERY_HIGH;
-    case value >= 50:
-      return StatColors.HIGH;
-    case value >= 30:
-      return StatColors.MID;
-    case value >= 10:
-      return StatColors.LOW;
+    case logvalue >= 95:
+      return StatsColors.VERY_HIGH;
+    case logvalue >= 70:
+      return StatsColors.HIGH;
+    case logvalue >= 40:
+      return StatsColors.MID;
+    case logvalue >= 20:
+      return StatsColors.LOW;
     default:
-      return StatColors.VERY_LOW;
+      return StatsColors.VERY_LOW;
   }
 }


### PR DESCRIPTION
## Overview

Se aplico escala logaritmica para los colores de los stats.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe)
